### PR TITLE
Add hybrid benchmark testing ACORN and post-filtering

### DIFF
--- a/Src/HNSW.Net.HybridBenchmark/Dataset.cs
+++ b/Src/HNSW.Net.HybridBenchmark/Dataset.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+namespace HNSW.Net.HybridBenchmark
+{
+    public static class Dataset
+    {
+        public static int[] GenerateRandomAttributes(int count, int seed = 42)
+        {
+            var random = new Random(seed);
+            var attributes = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                attributes[i] = random.Next(1, 13); // Range 1-12 inclusive
+            }
+            return attributes;
+        }
+
+        public static int[][] ComputeHybridGroundTruth(float[][] baseVectors, int[] baseAttributes, float[][] queryVectors, int[] queryAttributes, int k)
+        {
+            Console.WriteLine("Computing hybrid ground truth...");
+            var groundTruth = new int[queryVectors.Length][];
+
+            // To make this much faster, let's use Parallel.For
+            Parallel.For(0, queryVectors.Length, i =>
+            {
+                var queryVector = queryVectors[i];
+                var queryAttribute = queryAttributes[i];
+                var distances = new List<(int Id, float Distance)>();
+
+                for (int j = 0; j < baseVectors.Length; j++)
+                {
+                    if (baseAttributes[j] == queryAttribute)
+                    {
+                        float dist = L2Distance.SIMD(queryVector, baseVectors[j]);
+                        distances.Add((j, dist));
+                    }
+                }
+
+                distances.Sort((a, b) => a.Distance.CompareTo(b.Distance));
+                groundTruth[i] = new int[Math.Min(k, distances.Count)];
+                for (int j = 0; j < groundTruth[i].Length; j++)
+                {
+                    groundTruth[i][j] = distances[j].Id;
+                }
+
+                if (i > 0 && i % 1000 == 0)
+                {
+                    Console.WriteLine($"Computed ground truth for {i} queries");
+                }
+            });
+
+            Console.WriteLine("Finished computing hybrid ground truth.");
+            return groundTruth;
+        }
+        public static float[][] ReadFvecs(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            var results = new List<float[]>();
+            while (stream.Position < stream.Length)
+            {
+                int dim = reader.ReadInt32();
+                var vector = new float[dim];
+                for (int i = 0; i < dim; i++)
+                {
+                    vector[i] = reader.ReadSingle();
+                }
+                results.Add(vector);
+            }
+            return results.ToArray();
+        }
+
+        public static int[][] ReadIvecs(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            var results = new List<int[]>();
+            while (stream.Position < stream.Length)
+            {
+                int dim = reader.ReadInt32();
+                var vector = new int[dim];
+                for (int i = 0; i < dim; i++)
+                {
+                    vector[i] = reader.ReadInt32();
+                }
+                results.Add(vector);
+            }
+            return results.ToArray();
+        }
+
+        public static async Task DownloadAndExtractAsync(string workingDir)
+        {
+            string tarPath = Path.Combine(workingDir, "sift.tar.gz");
+            if (!File.Exists(tarPath))
+            {
+                Console.WriteLine("Downloading Sift1M dataset via curl...");
+                var psi = new ProcessStartInfo("curl", $"-L ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz -o \"{tarPath}\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                };
+                var process = Process.Start(psi);
+                if (process == null) throw new Exception("Failed to start curl");
+                await process.WaitForExitAsync();
+                if (process.ExitCode != 0)
+                {
+                    string error = await process.StandardError.ReadToEndAsync();
+                    throw new Exception($"curl failed with exit code {process.ExitCode}: {error}");
+                }
+            }
+
+            // Check if extracted files already exist to avoid re-extracting
+            string baseFile = Path.Combine(workingDir, "sift", "sift_base.fvecs");
+            if (!File.Exists(baseFile))
+            {
+                Console.WriteLine("Extracting Sift1M dataset...");
+                using var fsIn = File.OpenRead(tarPath);
+                using var gzipStream = new GZipStream(fsIn, CompressionMode.Decompress);
+                TarFile.ExtractToDirectory(gzipStream, workingDir, true);
+            }
+        }
+    }
+}

--- a/Src/HNSW.Net.HybridBenchmark/HNSW.Net.HybridBenchmark.csproj
+++ b/Src/HNSW.Net.HybridBenchmark/HNSW.Net.HybridBenchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HNSW.Net\HNSW.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/HNSW.Net.HybridBenchmark/HybridBenchmark.cs
+++ b/Src/HNSW.Net.HybridBenchmark/HybridBenchmark.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using HNSW.Net;
+
+namespace HNSW.Net.HybridBenchmark
+{
+    public struct Item
+    {
+        public int Id;
+        public float[] Vector;
+        public int Attribute;
+    }
+
+    public class HybridBenchmark
+    {
+        private static float[][] _baseVectors;
+        private static float[][] _queryVectors;
+
+        private static Item[] _baseItems;
+        private static Item[] _queryItems;
+
+        private static int[][] _groundTruth;
+
+        private static SmallWorld<Item, float> _cachedGraph;
+        private static (int M, int EfConstruction, bool OptimizeForFiltering, int Gamma, int Mb) _cachedGraphParams;
+
+        private SmallWorld<Item, float> _graph;
+
+        [Params(16)]
+        public int M { get; set; }
+
+        [Params(200)]
+        public int EfConstruction { get; set; }
+
+        [Params(50, 100, 200)]
+        public int EfSearch { get; set; }
+
+        // By default false, which means it will do Post-Filtering
+        [Params(false, true)]
+        public bool OptimizeForFiltering { get; set; }
+
+        public int Gamma { get; set; } = 12; // Typical value for SIFT1M per paper
+        public int Mb { get; set; } = 16; // Small multiple of M, typically M, 2M, or 64. Using M.
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string workingDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data");
+            if (!Directory.Exists(workingDir)) Directory.CreateDirectory(workingDir);
+
+            Dataset.DownloadAndExtractAsync(workingDir).GetAwaiter().GetResult();
+
+            string siftDir = Path.Combine(workingDir, "sift");
+            if (_baseVectors == null)
+            {
+                Console.WriteLine("Reading dataset...");
+                _baseVectors = Dataset.ReadFvecs(Path.Combine(siftDir, "sift_base.fvecs"));
+                _queryVectors = Dataset.ReadFvecs(Path.Combine(siftDir, "sift_query.fvecs"));
+
+                var baseAttributes = Dataset.GenerateRandomAttributes(_baseVectors.Length, seed: 42);
+                var queryAttributes = Dataset.GenerateRandomAttributes(_queryVectors.Length, seed: 43);
+
+                _baseItems = new Item[_baseVectors.Length];
+                for (int i = 0; i < _baseVectors.Length; i++)
+                {
+                    _baseItems[i] = new Item { Id = i, Vector = _baseVectors[i], Attribute = baseAttributes[i] };
+                }
+
+                _queryItems = new Item[_queryVectors.Length];
+                for (int i = 0; i < _queryVectors.Length; i++)
+                {
+                    _queryItems[i] = new Item { Id = i, Vector = _queryVectors[i], Attribute = queryAttributes[i] };
+                }
+
+                _groundTruth = Dataset.ComputeHybridGroundTruth(_baseVectors, baseAttributes, _queryVectors, queryAttributes, 10);
+
+                Console.WriteLine($"Loaded {_baseVectors.Length} base vectors");
+                Console.WriteLine($"Loaded {_queryVectors.Length} query vectors");
+            }
+
+            if (_cachedGraph == null || _cachedGraphParams.M != M || _cachedGraphParams.EfConstruction != EfConstruction ||
+                _cachedGraphParams.OptimizeForFiltering != OptimizeForFiltering ||
+                _cachedGraphParams.Gamma != Gamma || _cachedGraphParams.Mb != Mb)
+            {
+                var parameters = new SmallWorldParameters
+                {
+                    M = M,
+                    LevelLambda = 1 / Math.Log(M),
+                    ConstructionPruning = EfConstruction,
+                    EfSearch = EfSearch,
+                    EnableDistanceCacheForConstruction = true,
+                    OptimizeForFiltering = OptimizeForFiltering,
+                    Gamma = Gamma,
+                    Mb = Mb
+                };
+
+                Console.WriteLine($"Building graph with M={M}, EfConstruction={EfConstruction}, OptimizeForFiltering={OptimizeForFiltering}, Gamma={Gamma}, Mb={Mb}...");
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+
+                // Using distance function that only cares about vector
+                float DistanceFunc(Item a, Item b) => L2Distance.SIMD(a.Vector, b.Vector);
+
+                var graph = new SmallWorld<Item, float>(DistanceFunc, DefaultRandomGenerator.Instance, parameters);
+                graph.AddItems(_baseItems);
+                sw.Stop();
+                Console.WriteLine($"Graph built in {sw.Elapsed.TotalSeconds:N2}s.");
+
+                _cachedGraph = graph;
+                _cachedGraphParams = (M, EfConstruction, OptimizeForFiltering, Gamma, Mb);
+            }
+
+            _graph = _cachedGraph;
+            _graph.Parameters.EfSearch = EfSearch;
+        }
+
+        [Benchmark]
+        public void Search()
+        {
+            for (int i = 0; i < _queryItems.Length; i++)
+            {
+                var queryItem = _queryItems[i];
+                // Post-filter matching the attribute. With OptimizeForFiltering=true it will do predicate subgraph traversal.
+                _graph.KNNSearch(queryItem, 10, item => item.Attribute == queryItem.Attribute);
+            }
+        }
+
+        [IterationCleanup]
+        public void Cleanup()
+        {
+            int correct1 = 0;
+            int correct10 = 0;
+            int total = _queryItems.Length;
+
+            for (int i = 0; i < total; i++)
+            {
+                var queryItem = _queryItems[i];
+                var results1 = _graph.KNNSearch(queryItem, 1, item => item.Attribute == queryItem.Attribute);
+                if (results1.Count > 0 && results1[0].Item.Id == _groundTruth[i][0])
+                {
+                    correct1++;
+                }
+
+                var results10 = _graph.KNNSearch(queryItem, 10, item => item.Attribute == queryItem.Attribute);
+                if (results10.Any(r => r.Item.Id == _groundTruth[i][0]))
+                {
+                    correct10++;
+                }
+            }
+
+            double recall1 = (double)correct1 / total;
+            double recall10 = (double)correct10 / total;
+            Console.WriteLine($"[Configuration M={M}, EfConstruction={EfConstruction}, EfSearch={EfSearch}, OptimizeForFiltering={OptimizeForFiltering}] Recall@1: {recall1:P2}, Recall@10: {recall10:P2}");
+        }
+    }
+}

--- a/Src/HNSW.Net.HybridBenchmark/L2Distance.cs
+++ b/Src/HNSW.Net.HybridBenchmark/L2Distance.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace HNSW.Net.HybridBenchmark
+{
+    public static class L2Distance
+    {
+        private static readonly int _vs1 = Vector<float>.Count;
+        private static readonly int _vs2 = 2 * Vector<float>.Count;
+        private static readonly int _vs3 = 3 * Vector<float>.Count;
+        private static readonly int _vs4 = 4 * Vector<float>.Count;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float SIMD(float[] u, float[] v)
+        {
+            float result = 0f;
+            var count = u.Length;
+            var offset = 0;
+
+            while (count >= _vs4)
+            {
+                var v_u1 = new Vector<float>(u, offset);
+                var v_v1 = new Vector<float>(v, offset);
+                var diff1 = Vector.Subtract(v_u1, v_v1);
+                result += Vector.Dot(diff1, diff1);
+
+                var v_u2 = new Vector<float>(u, offset + _vs1);
+                var v_v2 = new Vector<float>(v, offset + _vs1);
+                var diff2 = Vector.Subtract(v_u2, v_v2);
+                result += Vector.Dot(diff2, diff2);
+
+                var v_u3 = new Vector<float>(u, offset + _vs2);
+                var v_v3 = new Vector<float>(v, offset + _vs2);
+                var diff3 = Vector.Subtract(v_u3, v_v3);
+                result += Vector.Dot(diff3, diff3);
+
+                var v_u4 = new Vector<float>(u, offset + _vs3);
+                var v_v4 = new Vector<float>(v, offset + _vs3);
+                var diff4 = Vector.Subtract(v_u4, v_v4);
+                result += Vector.Dot(diff4, diff4);
+
+                if (count == _vs4) return result;
+                count -= _vs4;
+                offset += _vs4;
+            }
+
+            if (count >= _vs2)
+            {
+                var diff1 = Vector.Subtract(new Vector<float>(u, offset), new Vector<float>(v, offset));
+                result += Vector.Dot(diff1, diff1);
+                var diff2 = Vector.Subtract(new Vector<float>(u, offset + _vs1), new Vector<float>(v, offset + _vs1));
+                result += Vector.Dot(diff2, diff2);
+                if (count == _vs2) return result;
+                count -= _vs2;
+                offset += _vs2;
+            }
+            if (count >= _vs1)
+            {
+                var diff1 = Vector.Subtract(new Vector<float>(u, offset), new Vector<float>(v, offset));
+                result += Vector.Dot(diff1, diff1);
+                if (count == _vs1) return result;
+                count -= _vs1;
+                offset += _vs1;
+            }
+            while (count > 0)
+            {
+                float diff = u[offset] - v[offset];
+                result += diff * diff;
+                offset++;
+                count--;
+            }
+            return result;
+        }
+
+        public static float NonOptimized(float[] u, float[] v)
+        {
+            float result = 0f;
+            for (int i = 0; i < u.Length; i++)
+            {
+                float diff = u[i] - v[i];
+                result += diff * diff;
+            }
+            return result;
+        }
+    }
+}

--- a/Src/HNSW.Net.HybridBenchmark/Program.cs
+++ b/Src/HNSW.Net.HybridBenchmark/Program.cs
@@ -1,0 +1,14 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+namespace HNSW.Net.HybridBenchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var config = DefaultConfig.Instance;
+            BenchmarkRunner.Run<HybridBenchmark>(config, args);
+        }
+    }
+}

--- a/Src/HNSW.Net.sln
+++ b/Src/HNSW.Net.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.TestFiltering", "H
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.SiftBenchmark", "HNSW.Net.SiftBenchmark\HNSW.Net.SiftBenchmark.csproj", "{04E62DE0-8D42-48BE-B375-3270150672A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.HybridBenchmark", "HNSW.Net.HybridBenchmark\HNSW.Net.HybridBenchmark.csproj", "{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,18 @@ Global
 		{04E62DE0-8D42-48BE-B375-3270150672A3}.Release|x64.Build.0 = Release|Any CPU
 		{04E62DE0-8D42-48BE-B375-3270150672A3}.Release|x86.ActiveCfg = Release|Any CPU
 		{04E62DE0-8D42-48BE-B375-3270150672A3}.Release|x86.Build.0 = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|x64.Build.0 = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Debug|x86.Build.0 = Debug|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x64.ActiveCfg = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x64.Build.0 = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x86.ActiveCfg = Release|Any CPU
+		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a new benchmark project testing the recall and performance of hybrid search workloads. The benchmark downloads the SIFT1M dataset, assigns random attributes in the range 1-12 to each vector to mimic the exact testing methodology of "ACORN: Performant and Predicate-Agnostic Search Over Vector Embeddings and Structured Data", and evaluates `KNNSearch` using the predicate vs a newly generated ground truth.

Included are configurable parameters matching typical ACORN setups like `OptimizeForFiltering=true/false`.

---
*PR created automatically by Jules for task [14195389289805936306](https://jules.google.com/task/14195389289805936306) started by @theolivenbaum*