### PR TITLE
Cache HybridBenchmark data in temp directory

### DIFF
--- a/Src/HNSW.Net.HybridBenchmark/Dataset.cs
+++ b/Src/HNSW.Net.HybridBenchmark/Dataset.cs
@@ -94,6 +94,41 @@ namespace HNSW.Net.HybridBenchmark
             return results.ToArray();
         }
 
+        public static void SaveGroundTruth(int[][] groundTruth, string path)
+        {
+            using var stream = File.Create(path);
+            using var writer = new BinaryWriter(stream);
+            writer.Write(groundTruth.Length);
+            for (int i = 0; i < groundTruth.Length; i++)
+            {
+                var row = groundTruth[i];
+                writer.Write(row.Length);
+                for (int j = 0; j < row.Length; j++)
+                {
+                    writer.Write(row[j]);
+                }
+            }
+        }
+
+        public static int[][] LoadGroundTruth(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            int length = reader.ReadInt32();
+            var groundTruth = new int[length][];
+            for (int i = 0; i < length; i++)
+            {
+                int rowLength = reader.ReadInt32();
+                var row = new int[rowLength];
+                for (int j = 0; j < rowLength; j++)
+                {
+                    row[j] = reader.ReadInt32();
+                }
+                groundTruth[i] = row;
+            }
+            return groundTruth;
+        }
+
         public static async Task DownloadAndExtractAsync(string workingDir)
         {
             string tarPath = Path.Combine(workingDir, "sift.tar.gz");

--- a/Src/HNSW.Net.HybridBenchmark/HybridBenchmark.cs
+++ b/Src/HNSW.Net.HybridBenchmark/HybridBenchmark.cs
@@ -48,7 +48,7 @@ namespace HNSW.Net.HybridBenchmark
         [GlobalSetup]
         public void Setup()
         {
-            string workingDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data");
+            string workingDir = Path.Combine(Path.GetTempPath(), "hnsw-bench");
             if (!Directory.Exists(workingDir)) Directory.CreateDirectory(workingDir);
 
             Dataset.DownloadAndExtractAsync(workingDir).GetAwaiter().GetResult();
@@ -75,7 +75,17 @@ namespace HNSW.Net.HybridBenchmark
                     _queryItems[i] = new Item { Id = i, Vector = _queryVectors[i], Attribute = queryAttributes[i] };
                 }
 
-                _groundTruth = Dataset.ComputeHybridGroundTruth(_baseVectors, baseAttributes, _queryVectors, queryAttributes, 10);
+                string groundTruthPath = Path.Combine(workingDir, "groundTruth.bin");
+                if (File.Exists(groundTruthPath))
+                {
+                    Console.WriteLine("Loading hybrid ground truth...");
+                    _groundTruth = Dataset.LoadGroundTruth(groundTruthPath);
+                }
+                else
+                {
+                    _groundTruth = Dataset.ComputeHybridGroundTruth(_baseVectors, baseAttributes, _queryVectors, queryAttributes, 10);
+                    Dataset.SaveGroundTruth(_groundTruth, groundTruthPath);
+                }
 
                 Console.WriteLine($"Loaded {_baseVectors.Length} base vectors");
                 Console.WriteLine($"Loaded {_queryVectors.Length} query vectors");
@@ -85,30 +95,45 @@ namespace HNSW.Net.HybridBenchmark
                 _cachedGraphParams.OptimizeForFiltering != OptimizeForFiltering ||
                 _cachedGraphParams.Gamma != Gamma || _cachedGraphParams.Mb != Mb)
             {
-                var parameters = new SmallWorldParameters
-                {
-                    M = M,
-                    LevelLambda = 1 / Math.Log(M),
-                    ConstructionPruning = EfConstruction,
-                    EfSearch = EfSearch,
-                    EnableDistanceCacheForConstruction = true,
-                    OptimizeForFiltering = OptimizeForFiltering,
-                    Gamma = Gamma,
-                    Mb = Mb
-                };
-
-                Console.WriteLine($"Building graph with M={M}, EfConstruction={EfConstruction}, OptimizeForFiltering={OptimizeForFiltering}, Gamma={Gamma}, Mb={Mb}...");
-                var sw = System.Diagnostics.Stopwatch.StartNew();
-
-                // Using distance function that only cares about vector
+                string graphCachePath = Path.Combine(workingDir, $"graph_{M}_{EfConstruction}_{OptimizeForFiltering}_{Gamma}_{Mb}.bin");
                 float DistanceFunc(Item a, Item b) => L2Distance.SIMD(a.Vector, b.Vector);
 
-                var graph = new SmallWorld<Item, float>(DistanceFunc, DefaultRandomGenerator.Instance, parameters);
-                graph.AddItems(_baseItems);
-                sw.Stop();
-                Console.WriteLine($"Graph built in {sw.Elapsed.TotalSeconds:N2}s.");
+                if (File.Exists(graphCachePath))
+                {
+                    Console.WriteLine($"Loading graph from {graphCachePath}...");
+                    using var stream = File.OpenRead(graphCachePath);
+                    var (graph, _) = SmallWorld<Item, float>.DeserializeGraph(_baseItems, DistanceFunc, DefaultRandomGenerator.Instance, stream);
+                    _cachedGraph = graph;
+                }
+                else
+                {
+                    var parameters = new SmallWorldParameters
+                    {
+                        M = M,
+                        LevelLambda = 1 / Math.Log(M),
+                        ConstructionPruning = EfConstruction,
+                        EfSearch = EfSearch,
+                        EnableDistanceCacheForConstruction = true,
+                        OptimizeForFiltering = OptimizeForFiltering,
+                        Gamma = Gamma,
+                        Mb = Mb
+                    };
 
-                _cachedGraph = graph;
+                    Console.WriteLine($"Building graph with M={M}, EfConstruction={EfConstruction}, OptimizeForFiltering={OptimizeForFiltering}, Gamma={Gamma}, Mb={Mb}...");
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+
+                    var graph = new SmallWorld<Item, float>(DistanceFunc, DefaultRandomGenerator.Instance, parameters);
+                    graph.AddItems(_baseItems);
+                    sw.Stop();
+                    Console.WriteLine($"Graph built in {sw.Elapsed.TotalSeconds:N2}s.");
+
+                    Console.WriteLine($"Saving graph to {graphCachePath}...");
+                    using var stream = File.Create(graphCachePath);
+                    graph.SerializeGraph(stream);
+
+                    _cachedGraph = graph;
+                }
+
                 _cachedGraphParams = (M, EfConstruction, OptimizeForFiltering, Gamma, Mb);
             }
 


### PR DESCRIPTION
Changed `workingDir` to a persistent directory in `%temp%\\hnsw-bench` to avoid repeated download and extraction in `HNSW.Net.HybridBenchmark`.
Added custom serialization for the ground truth `int[][]` array using `BinaryWriter` and `BinaryReader`.
Added saving and loading of the `SmallWorld` graph to persistent storage across benchmark runs. The graph cache is named according to its core parameters `M`, `EfConstruction`, `OptimizeForFiltering`, `Gamma`, and `Mb`.

---
*PR created automatically by Jules for task [17378878504998270197](https://jules.google.com/task/17378878504998270197) started by @theolivenbaum*