### PR TITLE
Add HybridPareto benchmark project for HNSW, ACORN-1, and ACORN-Gamma

### DIFF
--- a/Src/HNSW.Net.HybridPareto/Dataset.cs
+++ b/Src/HNSW.Net.HybridPareto/Dataset.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace HNSW.Net.HybridPareto
+{
+    public static class Dataset
+    {
+        public static int[] GenerateRandomAttributes(int count, int seed = 42)
+        {
+            var random = new Random(seed);
+            var attributes = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                attributes[i] = random.Next(1, 13); // Range 1-12 inclusive
+            }
+            return attributes;
+        }
+
+        public static int[][] ComputeHybridGroundTruth(float[][] baseVectors, int[] baseAttributes, float[][] queryVectors, int[] queryAttributes, int k)
+        {
+            Console.WriteLine("Computing hybrid ground truth...");
+            var groundTruth = new int[queryVectors.Length][];
+
+            // To make this much faster, let's use Parallel.For
+            Parallel.For(0, queryVectors.Length, i =>
+            {
+                var queryVector = queryVectors[i];
+                var queryAttribute = queryAttributes[i];
+                var distances = new List<(int Id, float Distance)>();
+
+                for (int j = 0; j < baseVectors.Length; j++)
+                {
+                    if (baseAttributes[j] == queryAttribute)
+                    {
+                        float dist = L2Distance.SIMD(queryVector, baseVectors[j]);
+                        distances.Add((j, dist));
+                    }
+                }
+
+                distances.Sort((a, b) => a.Distance.CompareTo(b.Distance));
+                groundTruth[i] = new int[Math.Min(k, distances.Count)];
+                for (int j = 0; j < groundTruth[i].Length; j++)
+                {
+                    groundTruth[i][j] = distances[j].Id;
+                }
+
+                if (i > 0 && i % 1000 == 0)
+                {
+                    Console.WriteLine($"Computed ground truth for {i} queries");
+                }
+            });
+
+            Console.WriteLine("Finished computing hybrid ground truth.");
+            return groundTruth;
+        }
+        public static float[][] ReadFvecs(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            var results = new List<float[]>();
+            while (stream.Position < stream.Length)
+            {
+                int dim = reader.ReadInt32();
+                var vector = new float[dim];
+                for (int i = 0; i < dim; i++)
+                {
+                    vector[i] = reader.ReadSingle();
+                }
+                results.Add(vector);
+            }
+            return results.ToArray();
+        }
+
+        public static int[][] ReadIvecs(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            var results = new List<int[]>();
+            while (stream.Position < stream.Length)
+            {
+                int dim = reader.ReadInt32();
+                var vector = new int[dim];
+                for (int i = 0; i < dim; i++)
+                {
+                    vector[i] = reader.ReadInt32();
+                }
+                results.Add(vector);
+            }
+            return results.ToArray();
+        }
+
+        public static void SaveGroundTruth(int[][] groundTruth, string path)
+        {
+            using var stream = File.Create(path);
+            using var writer = new BinaryWriter(stream);
+            writer.Write(groundTruth.Length);
+            for (int i = 0; i < groundTruth.Length; i++)
+            {
+                var row = groundTruth[i];
+                writer.Write(row.Length);
+                for (int j = 0; j < row.Length; j++)
+                {
+                    writer.Write(row[j]);
+                }
+            }
+        }
+
+        public static int[][] LoadGroundTruth(string path)
+        {
+            using var stream = File.OpenRead(path);
+            using var reader = new BinaryReader(stream);
+            int length = reader.ReadInt32();
+            var groundTruth = new int[length][];
+            for (int i = 0; i < length; i++)
+            {
+                int rowLength = reader.ReadInt32();
+                var row = new int[rowLength];
+                for (int j = 0; j < rowLength; j++)
+                {
+                    row[j] = reader.ReadInt32();
+                }
+                groundTruth[i] = row;
+            }
+            return groundTruth;
+        }
+
+        public static async Task DownloadAndExtractAsync(string workingDir)
+        {
+            string tarPath = Path.Combine(workingDir, "sift.tar.gz");
+            if (!File.Exists(tarPath))
+            {
+                Console.WriteLine("Downloading Sift1M dataset...");
+                using var client = new FluentFTP.AsyncFtpClient("ftp.irisa.fr");
+                await client.Connect();
+                await client.DownloadFile(tarPath, "/local/texmex/corpus/sift.tar.gz");
+                await client.Disconnect();
+            }
+
+            // Check if extracted files already exist to avoid re-extracting
+            string baseFile = Path.Combine(workingDir, "sift", "sift_base.fvecs");
+            if (!File.Exists(baseFile))
+            {
+                Console.WriteLine("Extracting Sift1M dataset...");
+                using var fsIn = File.OpenRead(tarPath);
+                using var gzipStream = new GZipStream(fsIn, CompressionMode.Decompress);
+                TarFile.ExtractToDirectory(gzipStream, workingDir, true);
+            }
+        }
+    }
+}

--- a/Src/HNSW.Net.HybridPareto/HNSW.Net.HybridPareto.csproj
+++ b/Src/HNSW.Net.HybridPareto/HNSW.Net.HybridPareto.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentFTP" Version="54.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HNSW.Net\HNSW.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/HNSW.Net.HybridPareto/L2Distance.cs
+++ b/Src/HNSW.Net.HybridPareto/L2Distance.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace HNSW.Net.HybridPareto
+{
+    public static class L2Distance
+    {
+        private static readonly int _vs1 = Vector<float>.Count;
+        private static readonly int _vs2 = 2 * Vector<float>.Count;
+        private static readonly int _vs3 = 3 * Vector<float>.Count;
+        private static readonly int _vs4 = 4 * Vector<float>.Count;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float SIMD(float[] u, float[] v)
+        {
+            float result = 0f;
+            var count = u.Length;
+            var offset = 0;
+
+            while (count >= _vs4)
+            {
+                var v_u1 = new Vector<float>(u, offset);
+                var v_v1 = new Vector<float>(v, offset);
+                var diff1 = Vector.Subtract(v_u1, v_v1);
+                result += Vector.Dot(diff1, diff1);
+
+                var v_u2 = new Vector<float>(u, offset + _vs1);
+                var v_v2 = new Vector<float>(v, offset + _vs1);
+                var diff2 = Vector.Subtract(v_u2, v_v2);
+                result += Vector.Dot(diff2, diff2);
+
+                var v_u3 = new Vector<float>(u, offset + _vs2);
+                var v_v3 = new Vector<float>(v, offset + _vs2);
+                var diff3 = Vector.Subtract(v_u3, v_v3);
+                result += Vector.Dot(diff3, diff3);
+
+                var v_u4 = new Vector<float>(u, offset + _vs3);
+                var v_v4 = new Vector<float>(v, offset + _vs3);
+                var diff4 = Vector.Subtract(v_u4, v_v4);
+                result += Vector.Dot(diff4, diff4);
+
+                if (count == _vs4) return result;
+                count -= _vs4;
+                offset += _vs4;
+            }
+
+            if (count >= _vs2)
+            {
+                var diff1 = Vector.Subtract(new Vector<float>(u, offset), new Vector<float>(v, offset));
+                result += Vector.Dot(diff1, diff1);
+                var diff2 = Vector.Subtract(new Vector<float>(u, offset + _vs1), new Vector<float>(v, offset + _vs1));
+                result += Vector.Dot(diff2, diff2);
+                if (count == _vs2) return result;
+                count -= _vs2;
+                offset += _vs2;
+            }
+            if (count >= _vs1)
+            {
+                var diff1 = Vector.Subtract(new Vector<float>(u, offset), new Vector<float>(v, offset));
+                result += Vector.Dot(diff1, diff1);
+                if (count == _vs1) return result;
+                count -= _vs1;
+                offset += _vs1;
+            }
+            while (count > 0)
+            {
+                float diff = u[offset] - v[offset];
+                result += diff * diff;
+                offset++;
+                count--;
+            }
+            return result;
+        }
+
+        public static float NonOptimized(float[] u, float[] v)
+        {
+            float result = 0f;
+            for (int i = 0; i < u.Length; i++)
+            {
+                float diff = u[i] - v[i];
+                result += diff * diff;
+            }
+            return result;
+        }
+    }
+}

--- a/Src/HNSW.Net.HybridPareto/Program.cs
+++ b/Src/HNSW.Net.HybridPareto/Program.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using HNSW.Net;
+
+namespace HNSW.Net.HybridPareto
+{
+    public struct Item
+    {
+        public int Id;
+        public float[] Vector;
+        public int Attribute;
+    }
+
+    public class Result
+    {
+        public string Method { get; set; }
+        public int M { get; set; }
+        public int EfConstruction { get; set; }
+        public int EfSearch { get; set; }
+        public int Gamma { get; set; }
+        public int Mb { get; set; }
+        public double Qps { get; set; }
+        public double RecallAt10 { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            double percentage = 0.05;
+            if (args.Length > 0)
+            {
+                if (double.TryParse(args[0], out double parsedPercentage))
+                {
+                    percentage = parsedPercentage;
+                }
+                else
+                {
+                    Console.WriteLine($"Invalid percentage argument '{args[0]}', defaulting to {percentage}");
+                }
+            }
+
+            Console.WriteLine($"Using {percentage:P} of the SIFT dataset.");
+
+            string workingDir = Path.Combine(Path.GetTempPath(), "hnsw-bench");
+            if (!Directory.Exists(workingDir)) Directory.CreateDirectory(workingDir);
+
+            Dataset.DownloadAndExtractAsync(workingDir).GetAwaiter().GetResult();
+
+            string siftDir = Path.Combine(workingDir, "sift");
+            Console.WriteLine("Reading dataset...");
+            var baseVectorsFull = Dataset.ReadFvecs(Path.Combine(siftDir, "sift_base.fvecs"));
+            var queryVectorsFull = Dataset.ReadFvecs(Path.Combine(siftDir, "sift_query.fvecs"));
+
+            int keepBaseVectors = (int)(baseVectorsFull.Length * percentage);
+            int keepQueryVectors = (int)(queryVectorsFull.Length * percentage);
+            // Ensure we keep at least 1 query vector to avoid zero queries
+            if (keepQueryVectors == 0 && queryVectorsFull.Length > 0) keepQueryVectors = 1;
+
+            var baseVectors = baseVectorsFull.Take(keepBaseVectors).ToArray();
+            var queryVectors = queryVectorsFull.Take(keepQueryVectors).ToArray();
+
+            var baseAttributes = Dataset.GenerateRandomAttributes(baseVectors.Length, seed: 42);
+            var queryAttributes = Dataset.GenerateRandomAttributes(queryVectors.Length, seed: 43);
+
+            var baseItems = new Item[baseVectors.Length];
+            for (int i = 0; i < baseVectors.Length; i++)
+            {
+                baseItems[i] = new Item { Id = i, Vector = baseVectors[i], Attribute = baseAttributes[i] };
+            }
+
+            var queryItems = new Item[queryVectors.Length];
+            for (int i = 0; i < queryVectors.Length; i++)
+            {
+                queryItems[i] = new Item { Id = i, Vector = queryVectors[i], Attribute = queryAttributes[i] };
+            }
+
+            Console.WriteLine($"Subset: {baseVectors.Length}/{baseVectorsFull.Length} base vectors");
+            Console.WriteLine($"Subset: {queryVectors.Length}/{queryVectorsFull.Length} query vectors");
+
+            Console.WriteLine("Computing hybrid ground truth for subset...");
+            var groundTruth = Dataset.ComputeHybridGroundTruth(baseVectors, baseAttributes, queryVectors, queryAttributes, 10);
+
+            var results = new List<Result>();
+
+            int[] mValues = { 16, 32 };
+            int[] efConstructionValues = { 100, 200 };
+            int[] efSearchValues = { 64, 128, 256 };
+
+            float DistanceFunc(Item a, Item b) => L2Distance.SIMD(a.Vector, b.Vector);
+
+            foreach (var m in mValues)
+            {
+                foreach (var efConstruction in efConstructionValues)
+                {
+                    // Define configurations:
+                    // (MethodName, OptimizeForFiltering, Gamma, Mb)
+                    var configurations = new[]
+                    {
+                        ("HNSW", false, 0, 0),
+                        ("ACORN-1", true, 1, m),
+                        ("ACORN-Gamma12", true, 12, m),
+                        ("ACORN-Gamma24", true, 24, m)
+                    };
+
+                    foreach (var (method, optimizeForFiltering, gamma, mb) in configurations)
+                    {
+                        var parameters = new SmallWorldParameters
+                        {
+                            M = m,
+                            LevelLambda = 1 / Math.Log(m),
+                            ConstructionPruning = efConstruction,
+                            EnableDistanceCacheForConstruction = true,
+                            OptimizeForFiltering = optimizeForFiltering,
+                            Gamma = gamma,
+                            Mb = mb
+                        };
+
+                        Console.WriteLine($"\nBuilding {method} graph with M={m}, EfConstruction={efConstruction}...");
+                        var swBuild = Stopwatch.StartNew();
+                        var graph = new SmallWorld<Item, float>(DistanceFunc, DefaultRandomGenerator.Instance, parameters);
+                        graph.AddItems(baseItems, new ConsoleProgress());
+                        swBuild.Stop();
+                        Console.WriteLine($"Graph built in {swBuild.Elapsed.TotalSeconds:N2}s.");
+
+                        foreach (var efSearch in efSearchValues)
+                        {
+                            graph.Parameters.EfSearch = efSearch;
+
+                            Console.WriteLine($"Searching {method} with EfSearch={efSearch}...");
+
+                            // Warmup
+                            for (int i = 0; i < Math.Min(100, queryItems.Length); i++)
+                            {
+                                var q = queryItems[i];
+                                graph.KNNSearch(q, 10, item => item.Attribute == q.Attribute);
+                            }
+
+                            int correct10 = 0;
+                            var swSearch = Stopwatch.StartNew();
+                            for (int i = 0; i < queryItems.Length; i++)
+                            {
+                                var queryItem = queryItems[i];
+                                var searchResults = graph.KNNSearch(queryItem, 10, item => item.Attribute == queryItem.Attribute);
+
+                                if (searchResults.Any(r => r.Item.Id == groundTruth[i][0]))
+                                {
+                                    correct10++;
+                                }
+                            }
+                            swSearch.Stop();
+
+                            double recall10 = (double)correct10 / queryItems.Length;
+                            double qps = queryItems.Length / swSearch.Elapsed.TotalSeconds;
+
+                            Console.WriteLine($"  -> Recall@10: {recall10:P2}, QPS: {qps:N2}");
+
+                            results.Add(new Result
+                            {
+                                Method = method,
+                                M = m,
+                                EfConstruction = efConstruction,
+                                EfSearch = efSearch,
+                                Gamma = gamma,
+                                Mb = mb,
+                                Qps = qps,
+                                RecallAt10 = recall10
+                            });
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("\n--- Pareto Sets ---");
+
+            var groupedResults = results.GroupBy(r => r.Method);
+
+            foreach (var group in groupedResults)
+            {
+                Console.WriteLine($"\nMethod: {group.Key}");
+                Console.WriteLine($"{"M",-5} {"EfC",-5} {"EfS",-5} {"Gamma",-6} {"Mb",-4} {"QPS",-10} {"Recall@10",-10}");
+
+                var methodResults = group.ToList();
+                var paretoFront = new List<Result>();
+
+                foreach (var r in methodResults)
+                {
+                    bool isDominated = false;
+                    foreach (var other in methodResults)
+                    {
+                        if (other == r) continue;
+
+                        bool otherIsBetterOrEqual = other.Qps >= r.Qps && other.RecallAt10 >= r.RecallAt10;
+                        bool otherIsStrictlyBetter = other.Qps > r.Qps || other.RecallAt10 > r.RecallAt10;
+
+                        if (otherIsBetterOrEqual && otherIsStrictlyBetter)
+                        {
+                            isDominated = true;
+                            break;
+                        }
+                    }
+
+                    if (!isDominated)
+                    {
+                        paretoFront.Add(r);
+                    }
+                }
+
+                // Sort Pareto front by Recall@10
+                paretoFront = paretoFront.OrderBy(r => r.RecallAt10).ToList();
+
+                foreach (var p in paretoFront)
+                {
+                    Console.WriteLine($"{p.M,-5} {p.EfConstruction,-5} {p.EfSearch,-5} {p.Gamma,-6} {p.Mb,-4} {p.Qps,-10:F2} {p.RecallAt10,-10:P2}");
+                }
+            }
+        }
+    }
+
+    internal class ConsoleProgress : IProgressReporter
+    {
+        private Stopwatch _sw;
+        public void Progress(int current, int total)
+        {
+            if (_sw is null) _sw = Stopwatch.StartNew();
+            if (_sw.Elapsed.TotalSeconds > 5)
+            {
+                Console.WriteLine($"At {current:n0} of {total:n0} or {100f * current / total}%");
+                _sw.Restart();
+            }
+        }
+    }
+}

--- a/Src/HNSW.Net.sln
+++ b/Src/HNSW.Net.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.SiftBenchmark", "H
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.HybridBenchmark", "HNSW.Net.HybridBenchmark\HNSW.Net.HybridBenchmark.csproj", "{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HNSW.Net.HybridPareto", "HNSW.Net.HybridPareto\HNSW.Net.HybridPareto.csproj", "{E8FDEC43-AA42-4886-9D7C-1A17971F6750}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +104,18 @@ Global
 		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x64.Build.0 = Release|Any CPU
 		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x86.ActiveCfg = Release|Any CPU
 		{514D7B3B-2F70-4F98-9BFF-C8750F5C839F}.Release|x86.Build.0 = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|x64.Build.0 = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|x64.ActiveCfg = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|x64.Build.0 = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8FDEC43-AA42-4886-9D7C-1A17971F6750}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new `HybridPareto` benchmark project to the HNSW.Net solution. It is designed to run a scan on the parameters used to configure the HNSW index (such as `M`, `EfConstruction`, `EfSearch`, `Gamma`, and `Mb`) for three indexing methods: HNSW, ACORN-1, and ACORN-Gamma.

Key features:
- It does **not** use `BenchmarkDotNet`.
- Takes a configurable parameter to specify the percentage of the SIFT dataset to use (defaulting to 5%) to reduce total run time.
- Only computes ground truth and runs each parameter combination once over the dataset subset.
- Generates a table of QPS vs Recall@10 metrics.
- Computes and displays the Pareto set of optimal configurations for each method.

---
*PR created automatically by Jules for task [3381735103945874191](https://jules.google.com/task/3381735103945874191) started by @theolivenbaum*