### PR TITLE
Parallelize Hybrid Pareto benchmark search loop

### DIFF
--- a/Src/HNSW.Net.HybridPareto/Program.cs
+++ b/Src/HNSW.Net.HybridPareto/Program.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using HNSW.Net;
 
 namespace HNSW.Net.HybridPareto
@@ -149,15 +151,15 @@ namespace HNSW.Net.HybridPareto
                             {
                                 int correct = 0;
                                 var swSearch = Stopwatch.StartNew();
-                                for (int i = 0; i < queryItems.Length; i++)
+                                Parallel.For(0, queryItems.Length, i =>
                                 {
                                     var queryItem = queryItems[i];
                                     var searchResults = graph.KNNSearch(queryItem, limit, item => item.Attribute == queryItem.Attribute);
 
                                     var groundTruthIds = groundTruth[i].Take(limit).ToList();
                                     int matchCount = searchResults.Count(r => groundTruthIds.Contains(r.Item.Id));
-                                    correct += matchCount;
-                                }
+                                    Interlocked.Add(ref correct, matchCount);
+                                });
                                 swSearch.Stop();
 
                                 double recall = (double)correct / (queryItems.Length * limit);

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd Src/HNSW.Net.HybridPareto
-dotnet run -c Release

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd Src/HNSW.Net.HybridPareto
+dotnet run -c Release


### PR DESCRIPTION
- Updated `Src/HNSW.Net.HybridPareto/Program.cs` to execute search queries concurrently using `Parallel.For`.
- Used `Interlocked.Add` to thread-safely increment the correct match count.
- Added necessary using directives for multithreading.

---
*PR created automatically by Jules for task [1700227794527236700](https://jules.google.com/task/1700227794527236700) started by @theolivenbaum*