### PR TITLE
Add README to NuGet Package

### DIFF
--- a/Src/HNSW.Net/HNSW.Net.csproj
+++ b/Src/HNSW.Net/HNSW.Net.csproj
@@ -16,9 +16,13 @@
     <RepositoryUrl>https://github.com/curiosity-ai/hnsw.net</RepositoryUrl>
     <PackageTags>kNN, ANN, approximate nearest neighbor</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
- 
-  
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Added `<PackageReadmeFile>` and included `README.md` to `HNSW.Net.csproj` to display it on the NuGet package page.

---
*PR created automatically by Jules for task [3474277076967604207](https://jules.google.com/task/3474277076967604207) started by @theolivenbaum*