### PR TITLE
Fix TurboQuant distance calculations and residual correction

### DIFF
--- a/Src/HNSW.Net/TurboQuant.cs
+++ b/Src/HNSW.Net/TurboQuant.cs
@@ -217,9 +217,14 @@ public sealed class TurboQuant
                 differingBits += BitOperations.PopCount((uint)(minSpanA[j] ^ minSpanB[j]));
             }
 
-            // agreeMinusDisagree = (Total Valid Bits) - 2 * (Differing Bits)
-            int agreeMinusDisagree = _residualProjections - (2 * differingBits);
-            float correction = (float)agreeMinusDisagree / _residualProjections;
+            // The 1-bit sketch estimates the cosine of the angle between residuals:
+            // cos(theta) = cos(PI * differingBits / totalBits)
+            float correction = MathF.Cos(MathF.PI * differingBits / _residualProjections);
+
+            // Theoretical upper bound for MSE distortion of 3-bit Lloyd-Max:
+            // D_mse = sqrt(3)*pi/2 * (1/4^3) approx 0.0425
+            // So average squared norm of residual is roughly this value, but we just use 1/16f as an approximate scale factor here
+            // based on the original heuristic.
             result += a.Norm * b.Norm * correction / 16f;
         }
 

--- a/Src/HNSW.Net/TurboQuantDistance.cs
+++ b/Src/HNSW.Net/TurboQuantDistance.cs
@@ -23,7 +23,9 @@ namespace HNSW.Net
         /// <returns>Distance between u and v.</returns>
         public float GetDistance(EncodedVector u, EncodedVector v)
         {
-            return 1f - _quantizer.ApproxDot(u, v);
+            float dot = _quantizer.ApproxDot(u, v);
+            float dist = u.Norm * u.Norm + v.Norm * v.Norm - 2f * dot;
+            return dist < 0f ? 0f : dist;
         }
     }
 }


### PR DESCRIPTION
The previous TurboQuant implementation was computing `1f - dot` in `TurboQuantDistance.GetDistance`. Because the SIFT benchmark uses unnormalized vectors, their raw dot products can be very large, resulting in massive negative distances. This completely broke the HNSW graph search which expects non-negative monotonic distances (expecting Euclidean distance for SIFT).

This change replaces `1f - dot` with the standard Euclidean (Squared L2) distance formula derived from the norm and inner product approximations: `||u||^2 + ||v||^2 - 2 * dot`.

Additionally, it upgrades the 1-bit sketch residual estimation from a linear approximation to the mathematically correct Charikar estimation formula (`MathF.Cos`). These changes vastly improve the recall on the SIFT benchmark.

---
*PR created automatically by Jules for task [10573591136587214386](https://jules.google.com/task/10573591136587214386) started by @theolivenbaum*