### PR TITLE
Fix TurboQuant QJL Implementation

### DIFF
--- a/Src/HNSW.Net.SiftBenchmark/SiftBenchmarkTurboQuant.cs
+++ b/Src/HNSW.Net.SiftBenchmark/SiftBenchmarkTurboQuant.cs
@@ -63,40 +63,6 @@ namespace HNSW.Net.SiftBenchmark
 
                 Console.WriteLine($"Loaded {_baseVectors.Length} base vectors");
                 Console.WriteLine($"Loaded {_queryVectors.Length} query vectors");
-
-                Console.WriteLine("Normalizing dataset for TurboQuant...");
-                for (int i = 0; i < _baseVectors.Length; i++)
-                {
-                    float norm = 0;
-                    for (int j = 0; j < _baseVectors[i].Length; j++)
-                    {
-                        norm += _baseVectors[i][j] * _baseVectors[i][j];
-                    }
-                    norm = (float)Math.Sqrt(norm);
-                    if (norm > 0)
-                    {
-                        for (int j = 0; j < _baseVectors[i].Length; j++)
-                        {
-                            _baseVectors[i][j] /= norm;
-                        }
-                    }
-                }
-                for (int i = 0; i < _queryVectors.Length; i++)
-                {
-                    float norm = 0;
-                    for (int j = 0; j < _queryVectors[i].Length; j++)
-                    {
-                        norm += _queryVectors[i][j] * _queryVectors[i][j];
-                    }
-                    norm = (float)Math.Sqrt(norm);
-                    if (norm > 0)
-                    {
-                        for (int j = 0; j < _queryVectors[i].Length; j++)
-                        {
-                            _queryVectors[i][j] /= norm;
-                        }
-                    }
-                }
             }
 
             if (_cachedGraph == null || _cachedGraphParams.M != M || _cachedGraphParams.EfConstruction != EfConstruction)
@@ -112,7 +78,7 @@ namespace HNSW.Net.SiftBenchmark
 
                 Console.WriteLine($"Building TurboQuant graph with M={M}, EfConstruction={EfConstruction}...");
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                var quantizer = TurboQuant.Create(_baseVectors[0].Length, DefaultRandomGenerator.Instance);
+                var quantizer = TurboQuant.Create(_baseVectors[0].Length, DefaultRandomGenerator.Instance, bits: 3, residualProjections: 64);
                 var graph = new SmallWorldTurboQuant(quantizer, DefaultRandomGenerator.Instance, parameters, false);
                 graph.AddItems(_baseVectors, new ConsoleProgress());
                 sw.Stop();

--- a/Src/HNSW.Net/SmallWorldTurboQuant.cs
+++ b/Src/HNSW.Net/SmallWorldTurboQuant.cs
@@ -42,7 +42,7 @@ namespace HNSW.Net
 
         public IList<SmallWorld<EncodedVector, float>.KNNSearchResult> KNNSearch(float[] item, int k, Func<EncodedVector, bool> filterItem = null, CancellationToken cancellationToken = default)
         {
-            var encodedItem = _quantizer.Encode(item);
+            var encodedItem = _quantizer.Encode(item, isQuery: true);
             return _innerGraph.KNNSearch(encodedItem, k, filterItem, cancellationToken);
         }
 

--- a/Src/HNSW.Net/TurboQuant.cs
+++ b/Src/HNSW.Net/TurboQuant.cs
@@ -91,7 +91,7 @@ public sealed class TurboQuant
         return new TurboQuant(dimension, bits, residualProjections, rotationSigns, codebook, thresholds, residualProjection);
     }
 
-    public EncodedVector Encode(ReadOnlySpan<float> vector)
+    public EncodedVector Encode(ReadOnlySpan<float> vector, bool isQuery = false)
     {
         if (vector.Length != _dimension)
             throw new ArgumentException($"Expected vector length {_dimension}.");
@@ -122,19 +122,34 @@ public sealed class TurboQuant
         }
 
         byte[] residualBits = null;
+        float[] queryProjections = null;
 
         if (_residualProjections > 0 && _residualProjection is not null)
         {
-            var residual = new float[_dimension];
-            for (int i = 0; i < _dimension; i++)
+            if (isQuery)
             {
-                residual[i] = rotated[i] - reconstructedRotated[i];
+                queryProjections = new float[_residualProjections];
+                for (int r = 0; r < _residualProjections; r++)
+                {
+                    float dot = 0f;
+                    var row = _residualProjection[r];
+                    for (int c = 0; c < _dimension; c++)
+                        dot += row[c] * rotated[c];
+                    queryProjections[r] = dot;
+                }
             }
-
-            residualBits = ProjectToSignBits(residual, _residualProjection);
+            else
+            {
+                var residual = new float[_dimension];
+                for (int i = 0; i < _dimension; i++)
+                {
+                    residual[i] = rotated[i] - reconstructedRotated[i];
+                }
+                residualBits = ProjectToSignBits(residual, _residualProjection);
+            }
         }
 
-        return new EncodedVector(norm, indices, residualBits);
+        return new EncodedVector(norm, indices, residualBits, queryProjections);
     }
 
     public float[] Decode(EncodedVector encoded)
@@ -193,39 +208,42 @@ public sealed class TurboQuant
 
         float result = a.Norm * b.Norm * baseDot;
 
-        // Stage 2: Hardware Intrinsic PopCount for Residual Sketch
-        if (_residualProjections > 0 && a.ResidualBits != null && b.ResidualBits != null)
+        // Stage 2: QJL asymmetric error correction
+        if (_residualProjections > 0)
         {
-            int len = Math.Min(a.ResidualBits.Length, b.ResidualBits.Length);
-            ReadOnlySpan<byte> minSpanA = new ReadOnlySpan<byte>(a.ResidualBits, 0, len);
-            ReadOnlySpan<byte> minSpanB = new ReadOnlySpan<byte>(b.ResidualBits, 0, len);
-
-            ReadOnlySpan<ulong> ulongA = MemoryMarshal.Cast<byte, ulong>(minSpanA);
-            ReadOnlySpan<ulong> ulongB = MemoryMarshal.Cast<byte, ulong>(minSpanB);
-
-            int differingBits = 0;
-            for (int j = 0; j < ulongA.Length; j++)
+            if (a.QueryProjections != null && b.ResidualBits != null)
             {
-                differingBits += BitOperations.PopCount(ulongA[j] ^ ulongB[j]);
+                float correction = 0f;
+                for (int r = 0; r < _residualProjections; r++)
+                {
+                    bool sign = (b.ResidualBits[r >> 3] & (1 << (r & 7))) != 0;
+                    float b_K = sign ? 1f : -1f;
+                    correction += a.QueryProjections[r] * b_K;
+                }
+                correction /= _residualProjections;
+
+                // For QJL with 1-bit sign, the unbiased estimator scales by sqrt(pi/2) * ||e||.
+                // Assuming roughly constant residual norm for 3-bit quantization.
+                // MSE is roughly 0.0425, so norm is sqrt(0.0425) approx 0.206.
+                // sqrt(pi/2) * 0.206 approx 0.258.
+                // We'll scale the correction appropriately.
+                float scale = MathF.Sqrt(MathF.PI / 2f) * 0.206f;
+                result += a.Norm * b.Norm * correction * scale;
             }
-
-            // Handle trailing bytes that didn't fit neatly into 8-byte ulong blocks
-            int remainingBytesStart = ulongA.Length * 8;
-
-            for (int j = remainingBytesStart; j < len; j++)
+            else if (b.QueryProjections != null && a.ResidualBits != null)
             {
-                differingBits += BitOperations.PopCount((uint)(minSpanA[j] ^ minSpanB[j]));
+                float correction = 0f;
+                for (int r = 0; r < _residualProjections; r++)
+                {
+                    bool sign = (a.ResidualBits[r >> 3] & (1 << (r & 7))) != 0;
+                    float b_K = sign ? 1f : -1f;
+                    correction += b.QueryProjections[r] * b_K;
+                }
+                correction /= _residualProjections;
+
+                float scale = MathF.Sqrt(MathF.PI / 2f) * 0.206f;
+                result += a.Norm * b.Norm * correction * scale;
             }
-
-            // The 1-bit sketch estimates the cosine of the angle between residuals:
-            // cos(theta) = cos(PI * differingBits / totalBits)
-            float correction = MathF.Cos(MathF.PI * differingBits / _residualProjections);
-
-            // Theoretical upper bound for MSE distortion of 3-bit Lloyd-Max:
-            // D_mse = sqrt(3)*pi/2 * (1/4^3) approx 0.0425
-            // So average squared norm of residual is roughly this value, but we just use 1/16f as an approximate scale factor here
-            // based on the original heuristic.
-            result += a.Norm * b.Norm * correction / 16f;
         }
 
         return result;
@@ -609,14 +627,16 @@ public sealed class EncodedVector
     public float Norm { get; }
     public byte[] Indices { get; }
     public byte[] ResidualBits { get; }
-    public EncodedVector(float norm, byte[] indices, byte[] residualBits)
+    public float[] QueryProjections { get; }
+    public EncodedVector(float norm, byte[] indices, byte[] residualBits, float[] queryProjections = null)
     {
         Norm = norm;
         Indices = indices;
         ResidualBits = residualBits;
+        QueryProjections = queryProjections;
     }
 
-    public int ApproxCompressedBytes => sizeof(float) + sizeof(int) + Indices.Length + (ResidualBits?.Length ?? 0);
+    public int ApproxCompressedBytes => sizeof(float) + sizeof(int) + Indices.Length + (ResidualBits?.Length ?? 0) + (QueryProjections?.Length * sizeof(float) ?? 0);
 
     public byte[] ToByteArray()
     {


### PR DESCRIPTION
Implemented QJL (Quantized Johnson-Lindenstrauss) asymmetric estimator in TurboQuant as per blog post, and fixed SiftBenchmarkTurboQuant to enable QJL with 64 bit residual sketch and removed improper normalization.

---
*PR created automatically by Jules for task [4921700967903552637](https://jules.google.com/task/4921700967903552637) started by @theolivenbaum*